### PR TITLE
Split apply script into create-secret and patch-controllers.

### DIFF
--- a/files/cert-create-secret.sh
+++ b/files/cert-create-secret.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+echo "Generating Kubernetes certificate secret..."
+kubectl create secret tls webhook-server-cert -n kubemod-system --cert=server.pem --key=server-key.pem --dry-run=client -o yaml > webhook-server-cert.yaml
+echo "Applying certificate..."
+kubectl apply -f webhook-server-cert.yaml -n kubemod-system

--- a/files/cert-patch-webhooks.sh
+++ b/files/cert-patch-webhooks.sh
@@ -5,10 +5,6 @@ ca_bundle=$(cat ca.pem | base64 - | tr -d '\n' )
 sed -r -i "s|Cg==|$ca_bundle|" patch-mutating-webhook-configuration.json
 sed -r -i "s|Cg==|$ca_bundle|" patch-validating-webhook-configuration.json
 
-echo "Generating Kubernetes certificate secret..."
-kubectl create secret tls webhook-server-cert -n kubemod-system --cert=server.pem --key=server-key.pem --dry-run=client -o yaml > webhook-server-cert.yaml
-echo "Applying certificate..."
-kubectl apply -f webhook-server-cert.yaml -n kubemod-system
 echo "Applying mutating webhook configuration patch..."
 kubectl patch mutatingwebhookconfiguration kubemod-mutating-webhook-configuration --type=json --patch "$(cat patch-mutating-webhook-configuration.json)"
 echo "Applying validating webhook configuration patch..."

--- a/files/cert-renew.sh
+++ b/files/cert-renew.sh
@@ -2,4 +2,5 @@
 set -e
 
 source ./cert-generate.sh
-source ./cert-apply.sh
+source ./cert-create-secret.sh
+source ./cert-patch-webhooks.sh


### PR DESCRIPTION
Allows to have correct environment lifecycle control (create secret before deployment starts, patch mutator and validator after).