### PR TITLE
Made crt directory writeable for GID=0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN chmod +x \
     /usr/local/bin/cfssl \
     /usr/local/bin/cfssljson \
     /usr/local/bin/kubectl \
-  && adduser -u $NONROOT_UID -D nonroot $NONROOT_GID
-
-USER nonroot
+    && adduser -u $NONROOT_UID -D nonroot $NONROOT_GID \
+    && mkdir -p -m 775 /kubemod-crt
 
 COPY --chown=nonroot:nonroot files/ kubemod-crt/
+
+USER nonroot
 
 WORKDIR /kubemod-crt


### PR DESCRIPTION
In some environments, like OpenShift, certain security policies may restrict the numeric range for UID/GID's that can be used to run a container. A container in this scenario will run with a different UID/GID than the hardcoded values in the Dockerfile.

This presents a problem because the scripts don't have permission to write to the `/kubemod-crt` directory, which causes the cert generation to fail. This PR set's the `w` flag on the directory for all users