### PR TITLE
Keep the previous certificate in the bundle as well as the new one to prevent periods of service outage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=cfssl /usr/local/bin/cfssljson /usr/local/bin/cfssljson
 ARG NONROOT_UID=65532
 ARG NONROOT_GID=65532
 
-RUN apk add --no-cache jq \
+RUN apk add --no-cache jq coreutils \
  && adduser -u $NONROOT_UID -D nonroot $NONROOT_GID \
  && mkdir -p -m 775 /kubemod-crt \
  && chown nonroot:root /kubemod-crt

--- a/files/cert-patch-webhooks.sh
+++ b/files/cert-patch-webhooks.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 set -e
 
-ca_bundle=$(cat ca.pem | base64 - | tr -d '\n' )
+./cert-retrieve-previous-ca.sh --kind MutatingWebhookConfiguration --object kubemod-mutating-webhook-configuration --jsonpath '.webhooks[0].clientConfig.caBundle' >> previous_ca.pem
+ca_bundle=$(cat previous_ca.pem ca.pem | base64 - | tr -d '\n' )
 sed -r -i "s|Cg==|$ca_bundle|" patch-mutating-webhook-configuration.json
 sed -r -i "s|Cg==|$ca_bundle|" patch-validating-webhook-configuration.json
 

--- a/files/cert-retrieve-previous-ca.sh
+++ b/files/cert-retrieve-previous-ca.sh
@@ -27,6 +27,12 @@ function main {
 
     current_ca_bundle=$(kubectl get ${KIND} ${OBJECT} -o=jsonpath="{${JSONPATH}}")
     decoded_ca=$(echo "$current_ca_bundle" | base64 -d)
+
+    if [ -z "$decoded_ca" ]; then
+        echo "No bundle found" >&2
+        exit 0
+    fi
+
     num_certs=$(($(echo "$decoded_ca" | grep "^$PATTERN" | wc -l)))
     echo "${num_certs} certs found in file" >&2
     if [ "${num_certs}" -eq 1 ]; then

--- a/files/cert-retrieve-previous-ca.sh
+++ b/files/cert-retrieve-previous-ca.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# This tool focuses on extracting the last NUMCERTS certificates out of a bundle 
+# for an OBJECT of a specific KIND, utilising the JSONPATH to reach the bundle
+# It takes care of donwloading the bundle, decoding it, splitting it into separate
+# certificates and then returning a concatenation of the last NUMCERTS
+# This is useful in certificate rotation patterns where you want to keep 2
+# certificates in a valid state so that the swap does not disrupt anything
+
+
+PATTERN='-----BEGIN CERTIFICATE-----'
+function main {
+
+    NUMCERTS=1
+    while [ $# -gt 1 ] ; do
+        case $1 in
+            --kind)     KIND=$2; shift;;
+            --object)   OBJECT=$2; shift;;
+            --jsonpath) JSONPATH=$2; shift;;
+            --numcerts) NUMCERTS=$2; shift;;
+            *)          EXTRAS="${EXTRAS:-} $1";;
+        esac
+        shift
+    done
+    [ -n "${EXTRAS:-}" ] && echo "Unrecognized parameters: ${EXTRAS:-}" >&2
+
+    current_ca_bundle=$(kubectl get ${KIND} ${OBJECT} -o=jsonpath="{${JSONPATH}}")
+    decoded_ca=$(echo "$current_ca_bundle" | base64 -d)
+    num_certs=$(($(echo "$decoded_ca" | grep "^$PATTERN" | wc -l)))
+    echo "${num_certs} certs found in file" >&2
+    if [ "${num_certs}" -eq 1 ]; then
+        echo "$decoded_ca"
+        exit 0
+    fi
+
+    TMPDIR=$(mktemp -d )
+    echo "${decoded_ca}" | csplit -f "${TMPDIR}/cert_" - '/^'"${PATTERN}"'$/' '{'$((num_certs-1))'}' >&2
+    last_cert=$(ls ${TMPDIR}/cert_* | tail -${NUMCERTS})
+    cat $last_cert
+}
+
+main "$@"

--- a/files/cert-retrieve-previous-ca.sh
+++ b/files/cert-retrieve-previous-ca.sh
@@ -25,16 +25,17 @@ function main {
     done
     [ -n "${EXTRAS:-}" ] && echo "Unrecognized parameters: ${EXTRAS:-}" >&2
 
+    echo "Extracting previous CA certificate..." >&2
     current_ca_bundle=$(kubectl get ${KIND} ${OBJECT} -o=jsonpath="{${JSONPATH}}")
     decoded_ca=$(echo "$current_ca_bundle" | base64 -d)
 
     if [ -z "$decoded_ca" ]; then
-        echo "No bundle found" >&2
+        echo "No previous CA certificate found in ${KIND}/${OBJECT}" >&2
         exit 0
     fi
 
     num_certs=$(($(echo "$decoded_ca" | grep "^$PATTERN" | wc -l)))
-    echo "${num_certs} certs found in file" >&2
+    echo "[${num_certs}] previous CA certificates found, returning the last ${NUMCERTS}" >&2
     if [ "${num_certs}" -eq 1 ]; then
         echo "$decoded_ca"
         exit 0


### PR DESCRIPTION
During our tests we discovered that every time the certificates rotated we got a lot of TLS bad certificate errors in our cluster.
```2022/06/02 13:46:25 http: TLS handshake error from 10.213.162.79:60186: remote error: tls: bad certificate```

When we looked into it we discovered that the refresher sets the secret and the caBundle in the webhooks at the same time.
However, that does not account for the time it takes for a pod to get the secret updated and the operator to refresh the certificate.
During that period of time the control-plane is using the new caBundle and the operator the old one, failing all requests and provoking a service outage since none of the resources created at that time will be serviced by kubemod.

The proposed solution keeps the previous certificate in the bundle along with the new one, so that the operator can work well before and after swapping its own certificate.  
This means there are always 2 certificates in the caBundle and each certificate will be valid for 2 cron periods, if this is a concern, halving the cron period should work.